### PR TITLE
fix: IDP 1643 nel dettaglio metodo di pagamento vengono mostrate anche le iniziative a sconto

### DIFF
--- a/src/main/java/it/gov/pagopa/wallet/service/WalletServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/wallet/service/WalletServiceImpl.java
@@ -336,7 +336,9 @@ public class WalletServiceImpl implements WalletService {
     List<WalletDTO> walletDTOList = new ArrayList<>();
 
     for (Wallet wallet : walletList) {
-      walletDTOList.add(walletMapper.toInitiativeDTO(wallet));
+      if(WalletConstants.INITIATIVE_REWARD_TYPE_REFUND.equals(wallet.getInitiativeRewardType())){
+        walletDTOList.add(walletMapper.toInitiativeDTO(wallet));
+      }
     }
     initiativeListDTO.setInitiativeList(walletDTOList);
 

--- a/src/test/java/it/gov/pagopa/wallet/service/WalletServiceTest.java
+++ b/src/test/java/it/gov/pagopa/wallet/service/WalletServiceTest.java
@@ -1064,6 +1064,7 @@ class WalletServiceTest {
         TEST_WALLET.setIban(IBAN_OK);
         List<Wallet> walletList = new ArrayList<>();
         walletList.add(TEST_WALLET);
+        walletList.add(TEST_WALLET_DISCOUNT);
 
         Mockito.when(walletRepositoryMock.findByUserId(USER_ID)).thenReturn(walletList);
         Mockito.when(walletMapper.toInitiativeDTO(Mockito.any(Wallet.class))).thenReturn(WALLET_DTO);


### PR DESCRIPTION
**Description**

The purpose of this PR is to add a condition to filter out the DISCOUNT type initiatives when retrieving the details of a payment instrument so that only REFUND type initiatives are shown.

**List of changes**

-  Added condition to filter out discount type initiatives
-  Modified JUnit tests

**Motivation and context**

**How has this been tested?**

- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [X] Api Tests
- [ ] Load Tests  

**Types of changes**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist:**

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.