### PR TITLE
fix: IDP-1643-Moved condition to filter out discount type initiatives

### DIFF
--- a/src/main/java/it/gov/pagopa/wallet/service/WalletServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/wallet/service/WalletServiceImpl.java
@@ -336,9 +336,7 @@ public class WalletServiceImpl implements WalletService {
     List<WalletDTO> walletDTOList = new ArrayList<>();
 
     for (Wallet wallet : walletList) {
-      if(WalletConstants.INITIATIVE_REWARD_TYPE_REFUND.equals(wallet.getInitiativeRewardType())){
         walletDTOList.add(walletMapper.toInitiativeDTO(wallet));
-      }
     }
     initiativeListDTO.setInitiativeList(walletDTOList);
 
@@ -931,7 +929,8 @@ public class WalletServiceImpl implements WalletService {
       log.info("[GET_INSTRUMENT_DETAIL_ON_INITIATIVES] Get all initiatives still active for user");
       for (WalletDTO wallet : initiativeListDTO.getInitiativeList()) {
         if (!wallet.getStatus().equals(WalletStatus.UNSUBSCRIBED)
-            && !wallet.getEndDate().isBefore(LocalDate.now())) {
+                && !wallet.getEndDate().isBefore(LocalDate.now())
+                && WalletConstants.INITIATIVE_REWARD_TYPE_REFUND.equals(wallet.getInitiativeRewardType())) {
           initiativesStatusDTO.add(walletMapper.toInstrStatusOnInitiativeDTO(wallet));
         }
       }


### PR DESCRIPTION
**Description**

The purpose of this PR is to add a condition to filter out the DISCOUNT type initiatives when retrieving the details of a payment instrument so that only REFUND type initiatives are shown.

**List of changes**

-  Moved condition to filter out discount type initiatives

**Motivation and context**

**How has this been tested?**

- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [X] Api Tests
- [ ] Load Tests  

**Types of changes**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist:**

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.