### PR TITLE
fix: [IDP-1791] check formalControl only in prod env

### DIFF
--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -30,6 +30,7 @@ microservice-chart:
   envConfig:
     JAVA_TOOL_OPTIONS: "-Xms128m -Xmx4g -Djava.util.concurrent.ForkJoinPool.common.parallelism=7 -Dio.netty.eventLoopThreads=100 -javaagent:/app/applicationinsights-agent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=8001,suspend=n -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=3002 -Dcom.sun.management.jmxremote.rmi.port=3003 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
     INITIATIVE_LOGO_URL: "https://idpaydinitiativestorage.blob.core.windows.net/logo/"
+    IS_IBAN_FORMAL_CONTROL_ACTIVE: "false"
 
   envSecret:
     aks-api-url: cstar-d-weu-dev01-aks-apiserver-url

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -30,6 +30,7 @@ microservice-chart:
   envConfig:
     JAVA_TOOL_OPTIONS: "-Xms128m -Xmx4g -Djava.util.concurrent.ForkJoinPool.common.parallelism=7 -Dio.netty.eventLoopThreads=100 -javaagent:/app/applicationinsights-agent.jar"
     INITIATIVE_LOGO_URL: "https://idpaypinitiativestorage.blob.core.windows.net/logo/"
+    IS_IBAN_FORMAL_CONTROL_ACTIVE: "true"
 
   envSecret:
     aks-api-url: cstar-p-weu-prod01-aks-apiserver-url

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -30,6 +30,7 @@ microservice-chart:
   envConfig:
     JAVA_TOOL_OPTIONS: "-Xms128m -Xmx4g -Djava.util.concurrent.ForkJoinPool.common.parallelism=7 -Dio.netty.eventLoopThreads=100 -javaagent:/app/applicationinsights-agent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=8001,suspend=n -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=3002 -Dcom.sun.management.jmxremote.rmi.port=3003 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
     INITIATIVE_LOGO_URL: "https://idpayuinitiativestorage.blob.core.windows.net/logo/"
+    IS_IBAN_FORMAL_CONTROL_ACTIVE: "false"
 
   envSecret:
     aks-api-url: cstar-u-weu-uat01-aks-apiserver-url

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -59,6 +59,7 @@ microservice-chart:
     APPLICATIONINSIGHTS_INSTRUMENTATION_MICROMETER_ENABLED: "false"
     APPLICATIONINSIGHTS_PREVIEW_PROFILER_ENABLED: "false"
     INITIATIVE_LOGO_URL: "https://idpaydinitiativestorage.blob.core.windows.net/logo/"
+    IS_IBAN_FORMAL_CONTROL_ACTIVE: "false"
 
   envConfigMapExternals:
     idpay-common:

--- a/src/main/java/it/gov/pagopa/wallet/service/WalletServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/wallet/service/WalletServiceImpl.java
@@ -94,6 +94,9 @@ public class WalletServiceImpl implements WalletService {
   @Value("${spring.cloud.stream.bindings.consumerRefund-in-0.destination}")
   String transactionTopic;
 
+  @Value("${app.iban.formalControl}")
+  boolean isFormalControlIban;
+
   @Override
   public EnrollmentStatusDTO getEnrollmentStatus(String initiativeId, String userId) {
     long startTime = System.currentTimeMillis();
@@ -224,7 +227,9 @@ public class WalletServiceImpl implements WalletService {
     }
 
     iban = iban.toUpperCase();
-    formalControl(iban);
+    if (isFormalControlIban) {
+      formalControl(iban);
+    }
     wallet.setIban(iban);
     IbanQueueDTO ibanQueueDTO =
         new IbanQueueDTO(userId, initiativeId, iban, description, channel, LocalDateTime.now());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -342,3 +342,5 @@ app:
   initiative:
     logo:
       url: ${INITIATIVE_LOGO_URL}
+  iban:
+    formalControl: ${IS_IBAN_FORMAL_CONTROL_ACTIVE:false}

--- a/src/test/java/it/gov/pagopa/wallet/service/WalletServiceNoIbanFormalControlTest.java
+++ b/src/test/java/it/gov/pagopa/wallet/service/WalletServiceNoIbanFormalControlTest.java
@@ -1,0 +1,118 @@
+package it.gov.pagopa.wallet.service;
+
+import it.gov.pagopa.wallet.connector.InitiativeRestConnector;
+import it.gov.pagopa.wallet.connector.OnboardingRestConnector;
+import it.gov.pagopa.wallet.connector.PaymentInstrumentRestConnector;
+import it.gov.pagopa.wallet.dto.mapper.TimelineMapper;
+import it.gov.pagopa.wallet.dto.mapper.WalletMapper;
+import it.gov.pagopa.wallet.enums.WalletStatus;
+import it.gov.pagopa.wallet.event.producer.ErrorProducer;
+import it.gov.pagopa.wallet.event.producer.IbanProducer;
+import it.gov.pagopa.wallet.event.producer.NotificationProducer;
+import it.gov.pagopa.wallet.event.producer.TimelineProducer;
+import it.gov.pagopa.wallet.exception.WalletException;
+import it.gov.pagopa.wallet.model.Wallet;
+import it.gov.pagopa.wallet.repository.WalletRepository;
+import it.gov.pagopa.wallet.repository.WalletUpdatesRepository;
+import it.gov.pagopa.wallet.utils.AuditUtilities;
+import it.gov.pagopa.wallet.utils.Utilities;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+@ContextConfiguration(classes = WalletServiceImpl.class)
+@TestPropertySource(
+        locations = "classpath:application.yml",
+        properties = {
+                "app.iban.formalControl=false",
+        })
+class WalletServiceNoIbanFormalControlTest {
+
+    @MockBean
+    IbanProducer ibanProducer;
+    @MockBean
+    TimelineProducer timelineProducer;
+    @MockBean
+    ErrorProducer errorProducer;
+    @MockBean
+    NotificationProducer notificationProducer;
+    @MockBean
+    WalletRepository walletRepositoryMock;
+    @MockBean
+    WalletUpdatesRepository walletUpdatesRepositoryMock;
+    @MockBean
+    PaymentInstrumentRestConnector paymentInstrumentRestConnector;
+    @MockBean
+    OnboardingRestConnector onboardingRestConnector;
+    @MockBean
+    InitiativeRestConnector initiativeRestConnector;
+    @MockBean
+    WalletMapper walletMapper;
+    @MockBean
+    TimelineMapper timelineMapper;
+    @Autowired
+    WalletService walletService;
+    @MockBean
+    AuditUtilities auditUtilities;
+    @MockBean
+    Utilities utilities;
+
+    private static final String USER_ID = "TEST_USER_ID";
+    private static final String INITIATIVE_ID = "TEST_INITIATIVE_ID";
+    private static final String INITIATIVE_NAME = "TEST_INITIATIVE_NAME";
+    private static final String CHANNEL = "CHANNEL";
+    private static final String IBAN_KO_NOT_IT = "GB29NWBK60161331926819";
+    private static final String DESCRIPTION_OK = "conto cointestato";
+    private static final LocalDateTime TEST_DATE = LocalDateTime.now();
+    private static final LocalDate TEST_DATE_ONLY_DATE = LocalDate.now();
+    private static final BigDecimal TEST_AMOUNT = BigDecimal.valueOf(2.00);
+    private static final BigDecimal TEST_ACCRUED = BigDecimal.valueOf(40.00);
+    private static final BigDecimal TEST_REFUNDED = BigDecimal.valueOf(0.00);
+
+    private static final String INITIATIE_REWARD_TYPE_REFUND = "REFUND";
+
+    private static final Wallet TEST_WALLET =
+            Wallet.builder()
+                    .userId(USER_ID)
+                    .initiativeId(INITIATIVE_ID)
+                    .initiativeName(INITIATIVE_NAME)
+                    .acceptanceDate(TEST_DATE)
+                    .status(WalletStatus.NOT_REFUNDABLE.name())
+                    .endDate(TEST_DATE_ONLY_DATE)
+                    .amount(TEST_AMOUNT)
+                    .accrued(TEST_ACCRUED)
+                    .refunded(TEST_REFUNDED)
+                    .lastCounterUpdate(TEST_DATE)
+                    .initiativeRewardType(INITIATIE_REWARD_TYPE_REFUND)
+                    .build();
+
+    @Test
+    void enrollIban_ok_iban_not_italian() {
+        TEST_WALLET.setIban(null);
+        TEST_WALLET.setStatus(WalletStatus.NOT_REFUNDABLE_ONLY_INSTRUMENT.name());
+        TEST_WALLET.setEndDate(LocalDate.MAX);
+
+        Mockito.when(walletRepositoryMock.findByInitiativeIdAndUserId(INITIATIVE_ID, USER_ID))
+                .thenReturn(Optional.of(TEST_WALLET));
+
+        try {
+            walletService.enrollIban(INITIATIVE_ID, USER_ID, IBAN_KO_NOT_IT, CHANNEL, DESCRIPTION_OK);
+        } catch (WalletException e) {
+            Assertions.fail();
+        }
+    }
+
+}

--- a/src/test/java/it/gov/pagopa/wallet/service/WalletServiceTest.java
+++ b/src/test/java/it/gov/pagopa/wallet/service/WalletServiceTest.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.math.BigDecimal;
@@ -52,6 +53,11 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith({SpringExtension.class, MockitoExtension.class})
 @ContextConfiguration(classes = WalletServiceImpl.class)
+@TestPropertySource(
+        locations = "classpath:application.yml",
+        properties = {
+                "app.iban.formalControl=true",
+        })
 class WalletServiceTest {
 
     @MockBean


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The purpose of this PR is to skip iban formal control in dev and uat environments in order to allow fake iban enrollment.

#### List of Changes
<!--- Describe your changes in detail -->
- add boolean env variables
- apply formal control only in prod environment

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
    - [x] Unit
    - [ ] Integration (Narrow)
- Post-Deploy Test
    - [ ] Isolated Microservice
    - [ ] Broader Integration
    - [ ] Acceptance
    - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
